### PR TITLE
Fix rpc ports in help output

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -319,7 +319,7 @@ std::string HelpMessage()
         "  -socks=<n>             " + _("Select the version of socks proxy to use (4-5, default: 5)") + "\n" +
         "  -tor=<ip:port>         " + _("Use proxy to reach tor hidden services (default: same as -proxy)") + "\n"
         "  -dns                   " + _("Allow DNS lookups for -addnode, -seednode and -connect") + "\n" +
-        "  -port=<port>           " + _("Listen for connections on <port> (default: 9933 or testnet: 19933)") + "\n" +
+        "  -port=<port>           " + _("Listen for connections on <port> (default: 9932 or testnet: 19932)") + "\n" +
         "  -maxconnections=<n>    " + _("Maintain at most <n> connections to peers (default: 125)") + "\n" +
         "  -addnode=<ip>          " + _("Add a node to connect to and attempt to keep the connection open") + "\n" +
         "  -connect=<ip>          " + _("Connect only to the specified node(s)") + "\n" +


### PR DESCRIPTION
The help output did not match the actual ports: https://github.com/CatcoinOfficial/CatcoinRelease/blob/master/src/bitcoinrpc.cpp#L42
