### PR TITLE
Add checkpoints, and resolve and off-by-one bug

### DIFF
--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -52,13 +52,15 @@ namespace Checkpoints
 		(22900, uint256("0x44de4c262de678a23554dd06a6f57270815ea9d145f6c542ab2a8dfbd2ca242c"))
 		(22950, uint256("0xcecc4ab30b39fc09bf85eb191e64c1660ab2206c5f80953694997ec5c2db5338"))
 		(25890, uint256("0x4806f91100ae83904aa0113cc3acda8fe6ac422186243719a68b76c98e7487c2"))
+		(30000, uint256("0xff05303dc58caf2d102c85a0504ed16939c7840c91f5f0b37a5bf128e9afb73f"))
+		(31830, uint256("0x9275b100cd5e540177c285c8801a63e644e7611a60a49b50831f70df6e5ea825"))
 //		(23000, uint256("0x"))
 
 		;
 	static const CCheckpointData data = {
 		&mapCheckpoints,
-		1394847232, // * UNIX timestamp of last checkpoint block
-		80219,		// * total number of transactions between genesis and last checkpoint
+		1412473618, // * UNIX timestamp of last checkpoint block
+		90366,		// * total number of transactions between genesis and last checkpoint
 					//	 (the tx=... number in the SetBestChain debug.log lines)
 		1000.0		// * estimated number of transactions per day after checkpoint
 	};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1454,7 +1454,7 @@ bool ConnectBestBlock(CValidationState &state) {
 
 void CBlockHeader::UpdateTime(const CBlockIndex* pindexPrev)
 {
-    nTime = max(pindexPrev->GetMedianTimePast()+1, GetAdjustedTime());
+    nTime = max(pindexPrev->GetBlockTime()+nMinSpacing, GetAdjustedTime());
 
     // Updating time can change work required on testnet:
     if (fTestNet)
@@ -2329,7 +2329,7 @@ bool CBlock::AcceptBlock(CValidationState &state, CDiskBlockPos *dbp)
             return state.DoS(100, error("AcceptBlock(height=%d) : incorrect proof of work", nHeight));
 
 	if (nHeight > fork4Block){
-            if (GetBlockTime() <= (pindexPrev->GetBlockTime() + nMinSpacing))
+            if (GetBlockTime() < (pindexPrev->GetBlockTime() + nMinSpacing))
                 return state.Invalid(error("AcceptBlock(height=%d) : block's timestamp (%"PRI64d") is too soon after prev(%"PRI64d")", nHeight, GetBlockTime(), pindexPrev->GetBlockTime()));
 	} else if (nHeight > fork3Block) {
             if (GetBlockTime() <= pindexPrev->GetBlockTime() - 30) // allow 30 sec


### PR DESCRIPTION
The checkpoints have not been updated in a LONG time and this, in combination with an off-by-one comparison bug in the timestamp checking code result in potential network forking. This patch should also make it so that miners are given valid timestamps, where as previously the blocks would just get rejected if they came too fast.
