### PR TITLE
Changed protocolversion and minpeerprotoversion

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -25,13 +25,13 @@ extern const std::string CLIENT_DATE;
 // network protocol versioning
 //
 
-static const int PROTOCOL_VERSION = 70002;
+static const int PROTOCOL_VERSION = 70003;
 
 // intial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
 
 // disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 70002;
+static const int MIN_PEER_PROTO_VERSION = 70003;
 
 // nTime field added to CAddress, starting with this version;
 // if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
Change minpeerprotoversion to lock-out earlier clients and force client upgrade.

See:
https://github.com/FeatherCoin/Feathercoin/commit/14bb39d7cfc84cb56da3f3effa6909667e0945a0
https://github.com/dogecoin/dogecoin/blob/master/src/version.h